### PR TITLE
Fixes for SRL compiler

### DIFF
--- a/AnyAst/src/pt/up/fe/specs/anycompiler/parsers/JsonParser.java
+++ b/AnyAst/src/pt/up/fe/specs/anycompiler/parsers/JsonParser.java
@@ -138,7 +138,12 @@ public class JsonParser implements AnyParser {
                 continue;
             }
 
-            var attrValue = value.get(key);
+            Object attrValue = value.get(key);
+
+            if (attrValue instanceof List<?> list) {
+                attrValue = list.toArray(new Object[list.size()]);
+            }
+
             node.putValue(key, attrValue);
         }
 
@@ -167,7 +172,12 @@ public class JsonParser implements AnyParser {
                 continue;
             }
 
-            var attrValue = value.get(key);
+            Object attrValue = value.get(key);
+
+            if (attrValue instanceof List<?> list) {
+                attrValue = list.toArray(new Object[list.size()]);
+            }
+
             node.putValue(key, attrValue);
         }
 

--- a/AnyWeaver-JS/src-api/core.ts
+++ b/AnyWeaver-JS/src-api/core.ts
@@ -5,7 +5,7 @@
  * Remove this file if AnyWeaver Classic has died out.
  */
 
-const prefix = "anyweaver-js/api/";
+const prefix = "@specs-feup/anyweaver/api/";
 const coreImports: string[] = [];
 const sideEffectsOnlyImports: string[] = ["Joinpoints.js"];
 

--- a/AnyWeaver/resources/anyweaver/core.js
+++ b/AnyWeaver/resources/anyweaver/core.js
@@ -4,7 +4,7 @@
  * Do not use this file in new (clava-js) projects.
  * Remove this file if AnyWeaver Classic has died out.
  */
-const prefix = "anyweaver-js/api/";
+const prefix = "@specs-feup/anyweaver/api/";
 const coreImports = [];
 const sideEffectsOnlyImports = ["Joinpoints.js"];
 for (const sideEffectsOnlyImport of sideEffectsOnlyImports) {

--- a/AnyWeaver/src/pt/up/fe/specs/anycompiler/weaver/AnyWeaver.java
+++ b/AnyWeaver/src/pt/up/fe/specs/anycompiler/weaver/AnyWeaver.java
@@ -31,7 +31,7 @@ import java.util.*;
 public class AnyWeaver extends AAnyWeaver {
 
     private static final String WEAVER_NAME = "AnyWeaver";
-    private static final String WEAVER_API_NAME = "anyweaver-js";
+    private static final String WEAVER_API_NAME = "@specs-feup/anyweaver";
 
     private DataStore args;
     private AnyNode root;


### PR DESCRIPTION
The SRL compiler is currently not working.

The problem stems from the parsing of lists by the JsonParser class. List attributes are inserted into the AST nodes as ArrayLists. As such, an error is thrown when performing `node.get(key)` to retrieve the list, because the LARA framework does not know how to `wrapJoinPoint` an ArrayList.

The proper solution in my opinion would be to fix this on the LARA-JS side, by adding a way to wrap ArrayLists, but this fix is also acceptable. The solution is to convert all ArrayLists to Object[] on the JsonParser before inserting into the value into the node.

Finally, I've also updated all mentions of the previous NPM package name to the new package name.